### PR TITLE
filemanager.js - mark foldersOnlyList and filesOnlyList as observable

### DIFF
--- a/octoprint_filemanager/static/js/filemanager.js
+++ b/octoprint_filemanager/static/js/filemanager.js
@@ -87,14 +87,14 @@ $(function() {
             0
         );
 
-        self.foldersOnlyList = function() {
+        self.foldersOnlyList = ko.dependentObservable(function() {
             filter = function(data) { return data["type"] && data["type"] == "folder"; };
             return _.filter(self.fileListHelper.paginatedItems(), filter);
-        };
-        self.filesOnlyList = function() {
+        });
+        self.filesOnlyList = ko.dependentObservable(function() {
             filter = function(data) { return data["type"] && data["type"] != "folder"; };
             return _.filter(self.fileListHelper.paginatedItems(), filter);
-        };
+        });
 
         if (self.files.hasOwnProperty("allItems"))
             self.files.allItems.subscribe(function (newValue) {


### PR DESCRIPTION
Corrects files / folders not showing with Octoprint 1.3.6