### PR TITLE
Fix OctoPrint 1.5.0 Compatibility

### DIFF
--- a/octoprint_filemanager/static/js/ko.single_double_click.js
+++ b/octoprint_filemanager/static/js/ko.single_double_click.js
@@ -23,9 +23,9 @@ ko.bindingHandlers.singleOrDoubleClick = {
 
             clicks++;
             if (clicks === 1) {
-                $(element).disableSelection();
+                $(element).style('user-select', 'none');
                 setTimeout(function () {
-                    $(element).enableSelection();
+                    $(element).style('user-select', 'auto');
                     if (clicks === 1) {
                         if (singleHandler !== undefined) {
                             singleHandler.call(this, bindingContext.$data, e);

--- a/octoprint_filemanager/static/js/ko.single_double_click.js
+++ b/octoprint_filemanager/static/js/ko.single_double_click.js
@@ -23,9 +23,9 @@ ko.bindingHandlers.singleOrDoubleClick = {
 
             clicks++;
             if (clicks === 1) {
-                $(element).style('user-select', 'none');
+                $(element).css('user-select', 'none');
                 setTimeout(function () {
-                    $(element).style('user-select', 'auto');
+                    $(element).css('user-select', 'auto');
                     if (clicks === 1) {
                         if (singleHandler !== undefined) {
                             singleHandler.call(this, bindingContext.$data, e);


### PR DESCRIPTION
Changes necessary to resolve issues with OctoPrint 1.5.0 and it's upgraded jQuery version that has deprecated enabledSelection/disableSelection. 